### PR TITLE
Update QRCodeCard.ts

### DIFF
--- a/src/QRCodeCard.ts
+++ b/src/QRCodeCard.ts
@@ -30,8 +30,8 @@ export const QRCodeCard = (
     color: profileBasics.highlightColor, // was "text-decoration-color"
   });
   const qrCodeCanvasStyle = 'width: 80%; margin:auto;'
-  const highlightColor = profileBasics.highlightColor || '#000000'
-  const backgroundColor = profileBasics.backgroundColor || '#ffffff'
+  const highlightColor = '#7c4cfc'
+  const backgroundColor = '#ffffff'
   // console.log(`@@ qrcodes colours highlightColor ${highlightColor}, backgroundColor ${backgroundColor}`)
 
   return html`


### PR DESCRIPTION
Shouldn't we change QRcode color to closer match the color scheme of Solid? Snapchat QR and Instagram QR have matching color schemes and distinctions for their codes as well. Changing the color does not seem to challenge or hurt a camera phones ability to absorb the information. I have already tested with my camera on the QRcode color scheme to make sure it can properly read the uri of the user. It would influence the user's interest in the aesthetic of UI/UX.